### PR TITLE
Handle missing objects in the linkintegrity

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Changelog
 2.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Handle missing objects when pages with
+  snippets have been deleted
+  [cdw9]
 
 
 2.0.4 (2017-08-30)

--- a/src/uwosh/snippets/linkintegrity.py
+++ b/src/uwosh/snippets/linkintegrity.py
@@ -47,6 +47,9 @@ def getSnippetRefsFromHtml(html):
 
 
 def findTextAreas(obj):
+    if not obj:
+        yield []
+        return
     fti = getUtility(IDexterityFTI, name=obj.portal_type)
     schema = fti.lookupSchema()
     additional_schema = getAdditionalSchemata(


### PR DESCRIPTION
Ignore missing objects when running `findTextAreas`, otherwise we get errors when editing a snippet that was added to a page that no longer exists. refs #17